### PR TITLE
Add a requirements.txt for use with pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+twisted
+klein
+treq


### PR DESCRIPTION
I don't know much about Python package management but this seemed to work with `pip install -r requrements.txt`
